### PR TITLE
feat: add --all support for batch PDF field extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 *.pdf
 *.log
+fieldmaps/*
+!fieldmaps/.keep

--- a/extract/extract-fields.js
+++ b/extract/extract-fields.js
@@ -9,15 +9,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const pdfName = argv[2];
 
-if (!pdfName) {
-  console.error("Please provide a PDF filename.\nUsage: node extract/extract-fields.js <filename.pdf>");
-  process.exit(1);
-};
+async function extractFields(pdfName) {
 
-const filePath = resolve(__dirname, `../pdfs/original/${pdfName}`);
-
-async function extractFields() {
-
+  const filePath = resolve(__dirname, `../pdfs/original/${pdfName}`);
   const fileBytes = fs.readFileSync(filePath);
   const pdfDoc = await PDFDocument.load(fileBytes);
 
@@ -35,7 +29,44 @@ async function extractFields() {
   const outputFilePath = resolve(__dirname, `../fieldmaps/${outputFileName}.json`);
 
   fs.writeFileSync(outputFilePath, strigifiedFieldInfo);
-  console.log(`Saved ${fields.length} fields to fieldmaps/insulation-certificate.json`)
+  console.log(`Saved ${fields.length} fields to fieldmaps/${outputFileName}.json`)
 }
 
-extractFields();
+async function main() {
+
+  if (argv.includes('--all')) {
+    // write batch here. 
+    const pdfNames = fs.readdirSync(resolve(__dirname, '../pdfs/original')).filter(f => f.endsWith('.pdf'));
+    try {
+      for (let i = 0; i < pdfNames.length; i++) {
+        await extractFields(pdfNames[i]);
+      }
+    }
+    catch (err) {
+      console.error(err)
+      process.exit(1)
+    }
+    finally {
+      process.exit(0);
+    }
+  }
+  else if (!!pdfName) {
+    try {
+      await extractFields(pdfName);
+    }
+    catch (err) {
+      console.error(err)
+      process.exit(1)
+    }
+    finally {
+      process.exit(0)
+    }
+  }
+
+  else {
+    console.error("Please provide a PDF filename.\nUsage: node extract/extract-fields.js <filename.pdf>");
+    process.exit(0);
+  };
+}
+
+main();


### PR DESCRIPTION
### Summary
Adds support for a `--all` flag to extract form fields from every PDF in `pdfs/original`.

### Changes
- Refactored `extractFields()` to be reusable
- Added CLI flag parsing via `process.argv`
- Added batch loop using `fs.readdirSync`
- Auto-generates fieldmaps for all `.pdf` files